### PR TITLE
Change block name compare to GTUtility.isOre

### DIFF
--- a/src/main/java/squeek/wailaharvestability/WailaHandler.java
+++ b/src/main/java/squeek/wailaharvestability/WailaHandler.java
@@ -61,7 +61,7 @@ public class WailaHandler implements IWailaDataProvider {
         EntityPlayer player = accessor.getPlayer();
 
         // for disguised blocks
-        if (itemStack.getItem() instanceof ItemBlock && !ProxyGregTech.isOreBlock(block)
+        if (itemStack.getItem() instanceof ItemBlock && !ProxyGregTech.isOreBlock(block, meta)
                 && !ProxyGregTech.isCasing(block)
                 && !ProxyGregTech.isMachine(block)) {
             block = Block.getBlockFromItem(itemStack.getItem());

--- a/src/main/java/squeek/wailaharvestability/proxy/ProxyGregTech.java
+++ b/src/main/java/squeek/wailaharvestability/proxy/ProxyGregTech.java
@@ -1,5 +1,9 @@
 package squeek.wailaharvestability.proxy;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
@@ -9,16 +13,41 @@ import cpw.mods.fml.common.registry.GameRegistry;
 public class ProxyGregTech {
 
     public static final String modID = "gregtech";
-    public static final String oreBlockID = "gt.blockores";
-    public static final String oreBlockUniqueIdentifier = modID + ":" + oreBlockID;
     public static final String casingID = "gt.blockcasings";
     public static final String casingUniqueIdentifier = modID + ":" + casingID;
     public static final String machineID = "gt.blockmachines";
     public static final String machineUniqueIdentifier = modID + ":" + machineID;
     public static boolean isModLoaded = Loader.isModLoaded(modID);
 
-    public static boolean isOreBlock(Block block) {
-        return isModLoaded && GameRegistry.findUniqueIdentifierFor(block).toString().equals(oreBlockUniqueIdentifier);
+    /**
+     * Use a nested class so that ProxyGregTech can load without loading GTMethods. This allows us to keep GTUTIL_IS_ORE
+     * static final without hacky code (MethodHandles have zero runtime cost if they're stored in a static final field).
+     */
+    private static class GTMethods {
+
+        public static final MethodHandle GTUTIL_IS_ORE;
+
+        static {
+            try {
+                GTUTIL_IS_ORE = MethodHandles.lookup().findStatic(
+                        Class.forName("gregtech.api.util.GTUtility"),
+                        "isOre",
+                        MethodType.methodType(boolean.class, Block.class, int.class));
+            } catch (NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static boolean isOreBlock(Block block, int meta) {
+        if (!isModLoaded) return false;
+
+        try {
+            // loads GTMethods
+            return (boolean) GTMethods.GTUTIL_IS_ORE.invokeExact(block, meta);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static boolean isCasing(Block block) {


### PR DESCRIPTION
I'm not entirely sure what bug this code is supposed to fix (something about disguised blocks/silverfish egg blocks), but I'll update it regardless since it refers to `gt.blockores`. It doesn't seem to break anything with or without the change.

related to but not dependent on: https://github.com/GTNewHorizons/GT5-Unofficial/pull/3662