### PR TITLE
Fix gregtech blocks showing incorrect harvest info

### DIFF
--- a/src/main/java/squeek/wailaharvestability/WailaHandler.java
+++ b/src/main/java/squeek/wailaharvestability/WailaHandler.java
@@ -60,18 +60,21 @@ public class WailaHandler implements IWailaDataProvider {
 
         EntityPlayer player = accessor.getPlayer();
 
+        boolean capMeta = true;
+
         // for disguised blocks
         if (itemStack.getItem() instanceof ItemBlock && !ProxyGregTech.isOreBlock(block, meta)
                 && !ProxyGregTech.isCasing(block)
                 && !ProxyGregTech.isMachine(block)) {
             block = Block.getBlockFromItem(itemStack.getItem());
             meta = itemStack.getItemDamage();
+            capMeta = false;
         }
 
         boolean minimalLayout = config.getConfig("harvestability.minimal", false);
 
-        List<String> stringParts = new ArrayList<String>();
-        getHarvestability(stringParts, player, block, meta, accessor.getPosition(), config, minimalLayout);
+        List<String> stringParts = new ArrayList<>();
+        getHarvestability(stringParts, player, block, meta, accessor.getPosition(), config, minimalLayout, capMeta);
 
         if (!stringParts.isEmpty()) {
             if (minimalLayout) toolTip.add(
@@ -85,7 +88,7 @@ public class WailaHandler implements IWailaDataProvider {
     }
 
     public void getHarvestability(List<String> stringList, EntityPlayer player, Block block, int meta,
-            MovingObjectPosition position, IWailaConfigHandler config, boolean minimalLayout) {
+            MovingObjectPosition position, IWailaConfigHandler config, boolean minimalLayout, boolean capMeta) {
         boolean isSneaking = player.isSneaking();
         boolean showHarvestLevel = config.getConfig("harvestability.harvestlevel")
                 && (!config.getConfig("harvestability.harvestlevel.sneakingonly") || isSneaking);
@@ -122,7 +125,7 @@ public class WailaHandler implements IWailaDataProvider {
 
             // needed to stop array index out of bounds exceptions on mob spawners
             // block.getHarvestLevel/getHarvestTool are only 16 elements big
-            if (meta >= 16) meta = 0;
+            if (meta >= 16 && capMeta) meta = 0;
 
             int harvestLevel = block.getHarvestLevel(meta);
             String effectiveTool = BlockHelper.getEffectiveToolOf(


### PR DESCRIPTION
The mod would cap the meta at 16 since vanilla blocks use an array and any meta above would cause an `ArrayIndexOutOfBoundsException`. GT machines and ores go well beyond this cap. In this case, we do not cap the meta.

These are from holding a wooden pickaxe, which can not mine diamond ore.
Before:
<img width="418" height="155" alt="image" src="https://github.com/user-attachments/assets/840623d3-a465-4777-8327-ff0df3fc2814" />

After:
<img width="465" height="179" alt="image" src="https://github.com/user-attachments/assets/24109a59-78e2-48b9-8a58-6842ecdd4851" />