### PR TITLE
Fix natural GT ores not showing mining level

### DIFF
--- a/src/main/java/squeek/wailaharvestability/WailaHandler.java
+++ b/src/main/java/squeek/wailaharvestability/WailaHandler.java
@@ -36,6 +36,7 @@ import squeek.wailaharvestability.helpers.StringHelper;
 import squeek.wailaharvestability.helpers.ToolHelper;
 import squeek.wailaharvestability.proxy.ProxyCreativeBlocks;
 import squeek.wailaharvestability.proxy.ProxyGregTech;
+import squeek.wailaharvestability.proxy.ProxyGregTech.GTBlockType;
 
 public class WailaHandler implements IWailaDataProvider {
 
@@ -60,17 +61,24 @@ public class WailaHandler implements IWailaDataProvider {
 
         EntityPlayer player = accessor.getPlayer();
 
+        // If we should limit the block metadata to 15
         boolean capMeta = true;
 
-        boolean isGtBlock = ProxyGregTech.isRelevantGTBlock(block);
+        GTBlockType gtBlockType = ProxyGregTech.getGTBlockType(block);
         if (itemStack.getItem() instanceof ItemBlock) {
-            if (isGtBlock) {
-                capMeta = false;
-            } else {
-                // for disguised blocks
+            // Use the actual block we are looking at for GT casings and machines since that determines
+            // the mining level needed
+            if (gtBlockType != GTBlockType.Casing && gtBlockType != GTBlockType.Machine) {
+                // Use the mining level of what the block is "saying" it is in the case that the block
+                // is hiding what it actually is
                 block = Block.getBlockFromItem(itemStack.getItem());
                 meta = itemStack.getItemDamage();
             }
+        }
+
+        // GT ores can go over the normal meta cap
+        if (gtBlockType == GTBlockType.Ore) {
+            capMeta = false;
         }
 
         boolean minimalLayout = config.getConfig("harvestability.minimal", false);

--- a/src/main/java/squeek/wailaharvestability/WailaHandler.java
+++ b/src/main/java/squeek/wailaharvestability/WailaHandler.java
@@ -62,13 +62,15 @@ public class WailaHandler implements IWailaDataProvider {
 
         boolean capMeta = true;
 
-        // for disguised blocks
-        if (itemStack.getItem() instanceof ItemBlock && !ProxyGregTech.isOreBlock(block, meta)
-                && !ProxyGregTech.isCasing(block)
-                && !ProxyGregTech.isMachine(block)) {
-            block = Block.getBlockFromItem(itemStack.getItem());
-            meta = itemStack.getItemDamage();
-            capMeta = false;
+        boolean isGtBlock = ProxyGregTech.isRelevantGTBlock(block);
+        if (itemStack.getItem() instanceof ItemBlock) {
+            if (isGtBlock) {
+                capMeta = false;
+            } else {
+                // for disguised blocks
+                block = Block.getBlockFromItem(itemStack.getItem());
+                meta = itemStack.getItemDamage();
+            }
         }
 
         boolean minimalLayout = config.getConfig("harvestability.minimal", false);

--- a/src/main/java/squeek/wailaharvestability/proxy/ProxyGregTech.java
+++ b/src/main/java/squeek/wailaharvestability/proxy/ProxyGregTech.java
@@ -20,7 +20,7 @@ public class ProxyGregTech {
     public static boolean isRelevantGTBlock(Block block) {
         if (!isModLoaded) return false;
         String blockId = GameRegistry.findUniqueIdentifierFor(block).toString();
-        return blockId.startsWith(oreUniqueIdentifier) || blockId.equals(casingUniqueIdentifier)
+        return blockId.startsWith(oreUniqueIdentifier) || blockId.startsWith(casingUniqueIdentifier)
                 || blockId.equals(machineUniqueIdentifier);
     }
 

--- a/src/main/java/squeek/wailaharvestability/proxy/ProxyGregTech.java
+++ b/src/main/java/squeek/wailaharvestability/proxy/ProxyGregTech.java
@@ -1,9 +1,5 @@
 package squeek.wailaharvestability.proxy;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
@@ -17,45 +13,15 @@ public class ProxyGregTech {
     public static final String casingUniqueIdentifier = modID + ":" + casingID;
     public static final String machineID = "gt.blockmachines";
     public static final String machineUniqueIdentifier = modID + ":" + machineID;
+    public static final String oreID = "gt.blockores";
+    public static final String oreUniqueIdentifier = modID + ":" + oreID;
     public static boolean isModLoaded = Loader.isModLoaded(modID) && !Loader.isModLoaded("gregapi");
 
-    /**
-     * Use a nested class so that ProxyGregTech can load without loading GTMethods. This allows us to keep GTUTIL_IS_ORE
-     * static final without hacky code (MethodHandles have zero runtime cost if they're stored in a static final field).
-     */
-    private static class GTMethods {
-
-        public static final MethodHandle GTUTIL_IS_ORE;
-
-        static {
-            try {
-                GTUTIL_IS_ORE = MethodHandles.lookup().findStatic(
-                        Class.forName("gregtech.api.util.GTUtility"),
-                        "isOre",
-                        MethodType.methodType(boolean.class, Block.class, int.class));
-            } catch (NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    public static boolean isOreBlock(Block block, int meta) {
+    public static boolean isRelevantGTBlock(Block block) {
         if (!isModLoaded) return false;
-
-        try {
-            // loads GTMethods
-            return (boolean) GTMethods.GTUTIL_IS_ORE.invokeExact(block, meta);
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static boolean isCasing(Block block) {
-        return isModLoaded && GameRegistry.findUniqueIdentifierFor(block).toString().equals(casingUniqueIdentifier);
-    }
-
-    public static boolean isMachine(Block block) {
-        return isModLoaded && GameRegistry.findUniqueIdentifierFor(block).toString().equals(machineUniqueIdentifier);
+        String blockId = GameRegistry.findUniqueIdentifierFor(block).toString();
+        return blockId.startsWith(oreUniqueIdentifier) || blockId.equals(casingUniqueIdentifier)
+                || blockId.equals(machineUniqueIdentifier);
     }
 
     public static boolean isGTTool(ItemStack itemStack) {

--- a/src/main/java/squeek/wailaharvestability/proxy/ProxyGregTech.java
+++ b/src/main/java/squeek/wailaharvestability/proxy/ProxyGregTech.java
@@ -17,14 +17,23 @@ public class ProxyGregTech {
     public static final String oreUniqueIdentifier = modID + ":" + oreID;
     public static boolean isModLoaded = Loader.isModLoaded(modID) && !Loader.isModLoaded("gregapi");
 
-    public static boolean isRelevantGTBlock(Block block) {
-        if (!isModLoaded) return false;
+    public static GTBlockType getGTBlockType(Block block) {
+        if (!isModLoaded) return GTBlockType.None;
         String blockId = GameRegistry.findUniqueIdentifierFor(block).toString();
-        return blockId.startsWith(oreUniqueIdentifier) || blockId.startsWith(casingUniqueIdentifier)
-                || blockId.equals(machineUniqueIdentifier);
+        if (blockId.startsWith(oreUniqueIdentifier)) return GTBlockType.Ore;
+        if (blockId.startsWith(casingUniqueIdentifier)) return GTBlockType.Casing;
+        if (blockId.equals(machineUniqueIdentifier)) return GTBlockType.Machine;
+        return GTBlockType.None;
     }
 
     public static boolean isGTTool(ItemStack itemStack) {
         return isModLoaded && itemStack.hasTagCompound() && itemStack.getTagCompound().hasKey("GT.ToolStats");
+    }
+
+    public enum GTBlockType {
+        None,
+        Ore,
+        Casing,
+        Machine
     }
 }


### PR DESCRIPTION
My previous fix https://github.com/GTNewHorizons/WailaHarvestability/pull/11 had a flaw in logic where instead of only gt stuff having uncapped meta, it was everything *but* gt stuff. Only reason it still worked was because ores that were manually placed were not "natural" and thus didn't count as ores in GT's isOre() method. 

This PR fixes the previous flaw in logic and checks ores regardless of if they are natural or not.

Still checking with strings to maintain backwards compatibility. 